### PR TITLE
Point to production of shared library

### DIFF
--- a/boilerplates/be-node-express/Jenkinsfile
+++ b/boilerplates/be-node-express/Jenkinsfile
@@ -8,7 +8,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@0.1-latest', retriever: modernSCM(
+library identifier: 'ods-library@production', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/be-python-flask/Jenkinsfile
+++ b/boilerplates/be-python-flask/Jenkinsfile
@@ -8,7 +8,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@0.1-latest', retriever: modernSCM(
+library identifier: 'ods-library@production', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/be-scala-akka/Jenkinsfile
+++ b/boilerplates/be-scala-akka/Jenkinsfile
@@ -8,7 +8,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@0.1-latest', retriever: modernSCM(
+library identifier: 'ods-library@production', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/be-springboot/Jenkinsfile
+++ b/boilerplates/be-springboot/Jenkinsfile
@@ -8,7 +8,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@0.1-latest', retriever: modernSCM(
+library identifier: 'ods-library@production', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/e2e-cypress/Jenkinsfile
+++ b/boilerplates/e2e-cypress/Jenkinsfile
@@ -8,7 +8,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@0.1-latest', retriever: modernSCM(
+library identifier: 'ods-library@production', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/fe-angular/Jenkinsfile
+++ b/boilerplates/fe-angular/Jenkinsfile
@@ -8,7 +8,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@0.1-latest', retriever: modernSCM(
+library identifier: 'ods-library@production', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/fe-ionic/Jenkinsfile
+++ b/boilerplates/fe-ionic/Jenkinsfile
@@ -8,7 +8,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@0.1-latest', retriever: modernSCM(
+library identifier: 'ods-library@production', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/fe-react/Jenkinsfile
+++ b/boilerplates/fe-react/Jenkinsfile
@@ -8,7 +8,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@0.1-latest', retriever: modernSCM(
+library identifier: 'ods-library@production', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])


### PR DESCRIPTION
Following up on
https://github.com/opendevstack/ods-jenkins-shared-library/pull/31,
each quickstarter should point to production of the shared library on
the master branch. In the release branches, this has to be updated.

Closes #63.