### PR TITLE
Add branchToEnvironmentMapping to Jenkinsfiles

### DIFF
--- a/boilerplates/be-node-express/Jenkinsfile
+++ b/boilerplates/be-node-express/Jenkinsfile
@@ -18,7 +18,10 @@ odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular",
   projectId: projectId,
   componentId: componentId,
-  verbose: true
+  branchToEnvironmentMapping: [
+    'master': 'test',
+    '*': 'dev'
+  ]
 ) { context ->
   stageBuild(context)
   stageUnitTest(context)

--- a/boilerplates/be-python-flask/Jenkinsfile
+++ b/boilerplates/be-python-flask/Jenkinsfile
@@ -18,8 +18,11 @@ odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-python",
   projectId: projectId,
   componentId: componentId,
-  verbose: true,
-  openshiftBuildTimeout: 25
+  openshiftBuildTimeout: 25,
+  branchToEnvironmentMapping: [
+    'master': 'test',
+    '*': 'dev'
+  ]
 ) { context ->
   stageBuild(context)
   stageScanForSonarqube(context)

--- a/boilerplates/be-scala-akka/Jenkinsfile
+++ b/boilerplates/be-scala-akka/Jenkinsfile
@@ -18,7 +18,10 @@ odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-scala",
   projectId: projectId,
   componentId: componentId,
-  verbose: true
+  branchToEnvironmentMapping: [
+    'master': 'test',
+    '*': 'dev'
+  ]
 ) { context ->
   stageBuild(context)
   stageScanForSonarqube(context)

--- a/boilerplates/be-springboot/Jenkinsfile
+++ b/boilerplates/be-springboot/Jenkinsfile
@@ -18,7 +18,10 @@ odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-maven",
   projectId: projectId,
   componentId: componentId,
-  verbose: true
+  branchToEnvironmentMapping: [
+    'master': 'test',
+    '*': 'dev'
+  ]
 ) { context ->
   stageBuild(context)
   stageScanForSonarqube(context)

--- a/boilerplates/e2e-cypress/Jenkinsfile
+++ b/boilerplates/e2e-cypress/Jenkinsfile
@@ -18,7 +18,10 @@ odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular",
   projectId: projectId,
   componentId: componentId,
-  verbose: true
+  branchToEnvironmentMapping: [
+    'master': 'test',
+    '*': 'dev'
+  ]
 ) { context ->
   stageTest(context)
 }

--- a/boilerplates/fe-angular/Jenkinsfile
+++ b/boilerplates/fe-angular/Jenkinsfile
@@ -18,7 +18,10 @@ odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular",
   projectId: projectId,
   componentId: componentId,
-  verbose: true
+  branchToEnvironmentMapping: [
+    'master': 'test',
+    '*': 'dev'
+  ]
 ) { context ->
   stageBuild(context)
   stageUnitTest(context)

--- a/boilerplates/fe-ionic/Jenkinsfile
+++ b/boilerplates/fe-ionic/Jenkinsfile
@@ -18,7 +18,10 @@ odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular",
   projectId: projectId,
   componentId: componentId,
-  verbose: true
+  branchToEnvironmentMapping: [
+    'master': 'test',
+    '*': 'dev'
+  ]
 ) { context ->
   stageBuild(context)
   stageUnitTest(context)

--- a/boilerplates/fe-react/Jenkinsfile
+++ b/boilerplates/fe-react/Jenkinsfile
@@ -18,7 +18,10 @@ odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular",
   projectId: projectId,
   componentId: componentId,
-  verbose: true
+  branchToEnvironmentMapping: [
+    'master': 'test',
+    '*': 'dev'
+  ]
 ) { context ->
   stageBuild(context)
   stageUnitTest(context)


### PR DESCRIPTION
Now that quickstarters point to the production branch of the shared
library, they need to work with this version, not with the old tag.

Removing verbose is in line with this - the new version of the shared
library does not have a verbose setting anymore. It displays quite a
lot by default, and allows to enable debug mode if needed.

Fixes #69.