### PR TITLE
Remove obsolete stages

### DIFF
--- a/boilerplates/be-node-express/Jenkinsfile
+++ b/boilerplates/be-node-express/Jenkinsfile
@@ -26,10 +26,8 @@ odsPipeline(
   stageBuild(context)
   stageUnitTest(context)
   stageScanForSonarqube(context)
-  stageCreateOpenshiftEnvironment(context)
   stageStartOpenshiftBuild(context)
   stageDeployToOpenshift(context)
-  stageTriggerAllBuilds(context)
 }
 
 def stageBuild(def context) {

--- a/boilerplates/be-python-flask/Jenkinsfile
+++ b/boilerplates/be-python-flask/Jenkinsfile
@@ -26,10 +26,8 @@ odsPipeline(
 ) { context ->
   stageBuild(context)
   stageScanForSonarqube(context)
-  stageCreateOpenshiftEnvironment(context)
   stageStartOpenshiftBuild(context)
   stageDeployToOpenshift(context)
-  stageTriggerAllBuilds(context)
 }
 
 def stageBuild(def context) {

--- a/boilerplates/be-scala-akka/Jenkinsfile
+++ b/boilerplates/be-scala-akka/Jenkinsfile
@@ -25,10 +25,8 @@ odsPipeline(
 ) { context ->
   stageBuild(context)
   stageScanForSonarqube(context)
-  stageCreateOpenshiftEnvironment(context)
   stageStartOpenshiftBuild(context)
   stageDeployToOpenshift(context)
-  stageTriggerAllBuilds(context)
 }
 
 def stageBuild(def context) {

--- a/boilerplates/be-springboot/Jenkinsfile
+++ b/boilerplates/be-springboot/Jenkinsfile
@@ -25,10 +25,8 @@ odsPipeline(
 ) { context ->
   stageBuild(context)
   stageScanForSonarqube(context)
-  stageCreateOpenshiftEnvironment(context)
   stageStartOpenshiftBuild(context)
   stageDeployToOpenshift(context)
-  stageTriggerAllBuilds(context)
 }
 
 def stageBuild(def context) {

--- a/boilerplates/fe-angular/Jenkinsfile
+++ b/boilerplates/fe-angular/Jenkinsfile
@@ -27,10 +27,8 @@ odsPipeline(
   stageUnitTest(context)
   stageLint(context)
   stageScanForSonarqube(context)
-  stageCreateOpenshiftEnvironment(context)
   stageStartOpenshiftBuild(context)
   stageDeployToOpenshift(context)
-  stageTriggerAllBuilds(context)
 }
 
 def stageBuild(def context) {

--- a/boilerplates/fe-ionic/Jenkinsfile
+++ b/boilerplates/fe-ionic/Jenkinsfile
@@ -27,10 +27,8 @@ odsPipeline(
   stageUnitTest(context)
   stageLint(context)
   stageScanForSonarqube(context)
-  stageCreateOpenshiftEnvironment(context)
   stageStartOpenshiftBuild(context)
   stageDeployToOpenshift(context)
-  stageTriggerAllBuilds(context)
 }
 
 def stageBuild(def context) {

--- a/boilerplates/fe-react/Jenkinsfile
+++ b/boilerplates/fe-react/Jenkinsfile
@@ -26,10 +26,8 @@ odsPipeline(
   stageBuild(context)
   stageUnitTest(context)
   stageScanForSonarqube(context)
-  stageCreateOpenshiftEnvironment(context)
   stageStartOpenshiftBuild(context)
   stageDeployToOpenshift(context)
-  stageTriggerAllBuilds(context)
 }
 
 def stageBuild(def context) {

--- a/boilerplates/jupyter-notebook/Jenkinsfile
+++ b/boilerplates/jupyter-notebook/Jenkinsfile
@@ -23,8 +23,6 @@ odsPipeline(
     '*': 'dev'
   ]
 ) { context ->
-  stageCreateOpenshiftEnvironment(context)
   stageStartOpenshiftBuild(context)
   stageDeployToOpenshift(context)
-  stageTriggerAllBuilds(context)
 }

--- a/boilerplates/rshiny/Jenkinsfile
+++ b/boilerplates/rshiny/Jenkinsfile
@@ -23,8 +23,6 @@ odsPipeline(
     '*': 'dev'
   ]
 ) { context ->
-  stageCreateOpenshiftEnvironment(context)
   stageStartOpenshiftBuild(context)
   stageDeployToOpenshift(context)
-  stageTriggerAllBuilds(context)
 }


### PR DESCRIPTION
Since https://github.com/opendevstack/ods-jenkins-shared-library/pull/43
is merged, we need to remove the now obsolete stages from each
Jenkinsfile.