### PR TITLE
Harden nginx config according to best practices

### DIFF
--- a/boilerplates/fe-angular/files/docker/nginx.vh.default.conf.nginx
+++ b/boilerplates/fe-angular/files/docker/nginx.vh.default.conf.nginx
@@ -1,7 +1,29 @@
+# config to don't allow the browser to render the page inside a frame or iframe
+# and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
+# if you need to allow [i]frames, you can use SAMEORIGIN or even set an uri with ALLOW-FROM uri
+# https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
+add_header X-Frame-Options SAMEORIGIN;
+
+# when serving user-supplied content, include a X-Content-Type-Options: nosniff header along with the Content-Type: header,
+# to disable content-type sniffing on some browsers.
+add_header X-Content-Type-Options nosniff;
+
+# This header enables the Cross-site scripting (XSS) filter built into most recent web browsers.
+# It's usually enabled by default anyway, so the role of this header is to re-enable the filter for
+# this particular website if it was disabled by the user.
+add_header X-XSS-Protection "1; mode=block" always;
+
+# config to enable HSTS(HTTP Strict Transport Security) https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
+# to avoid ssl stripping https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping
+# also https://hstspreload.org/
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
 server {
     listen       8080;
     server_name  localhost;
-	server_tokens off;
+
+    # don't send the nginx version number in error pages and Server header
+    server_tokens off;
 
     location / {
       root /docroot;

--- a/boilerplates/fe-ionic/files/docker/nginx.vh.default.conf.nginx
+++ b/boilerplates/fe-ionic/files/docker/nginx.vh.default.conf.nginx
@@ -1,6 +1,29 @@
+# config to don't allow the browser to render the page inside a frame or iframe
+# and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
+# if you need to allow [i]frames, you can use SAMEORIGIN or even set an uri with ALLOW-FROM uri
+# https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
+add_header X-Frame-Options SAMEORIGIN;
+
+# when serving user-supplied content, include a X-Content-Type-Options: nosniff header along with the Content-Type: header,
+# to disable content-type sniffing on some browsers.
+add_header X-Content-Type-Options nosniff;
+
+# This header enables the Cross-site scripting (XSS) filter built into most recent web browsers.
+# It's usually enabled by default anyway, so the role of this header is to re-enable the filter for
+# this particular website if it was disabled by the user.
+add_header X-XSS-Protection "1; mode=block" always;
+
+# config to enable HSTS(HTTP Strict Transport Security) https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
+# to avoid ssl stripping https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping
+# also https://hstspreload.org/
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
 server {
     listen       8080;
     server_name  localhost;
+
+    # don't send the nginx version number in error pages and Server header
+    server_tokens off;
 
     location / {
       root /docroot;

--- a/boilerplates/fe-react/files/docker/nginx.vh.default.conf.nginx
+++ b/boilerplates/fe-react/files/docker/nginx.vh.default.conf.nginx
@@ -1,6 +1,29 @@
+# config to don't allow the browser to render the page inside a frame or iframe
+# and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
+# if you need to allow [i]frames, you can use SAMEORIGIN or even set an uri with ALLOW-FROM uri
+# https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
+add_header X-Frame-Options SAMEORIGIN;
+
+# when serving user-supplied content, include a X-Content-Type-Options: nosniff header along with the Content-Type: header,
+# to disable content-type sniffing on some browsers.
+add_header X-Content-Type-Options nosniff;
+
+# This header enables the Cross-site scripting (XSS) filter built into most recent web browsers.
+# It's usually enabled by default anyway, so the role of this header is to re-enable the filter for
+# this particular website if it was disabled by the user.
+add_header X-XSS-Protection "1; mode=block" always;
+
+# config to enable HSTS(HTTP Strict Transport Security) https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
+# to avoid ssl stripping https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping
+# also https://hstspreload.org/
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
 server {
     listen       8080;
     server_name  localhost;
+
+    # don't send the nginx version number in error pages and Server header
+    server_tokens off;
 
     location / {
       root /docroot;


### PR DESCRIPTION
Related issue #100:
Harden nginx config according to best practices. See also https://gist.github.com/plentz/6737338 and the work on the WAF api quickstarter (opendevstack/ods-core#43).

Affected FE-related quickstarters are:
* fe-angular
* fe-ionic
* fe-react