### PR TITLE
Configure PROTECTED_BRANCHES in template to make it more explicit

### DIFF
--- a/ocp-templates/templates/cd-jenkins-webhook-proxy.yml
+++ b/ocp-templates/templates/cd-jenkins-webhook-proxy.yml
@@ -72,6 +72,8 @@ objects:
         - env:
           - name: REPO_BASE
             value: '${REPO_BASE}'
+          - name: PROTECTED_BRANCHES
+            value: ${PROTECTED_BRANCHES}
           - name: TRIGGER_SECRET
             valueFrom:
               secretKeyRef:
@@ -114,5 +116,7 @@ parameters:
   value: cd
 - name: REPO_BASE
   value: REPO_BASE
+- name: PROTECTED_BRANCHES
+  value: "master,develop,production,staging,release/"
 - name: PIPELINE_TRIGGER_SECRET
   value: PIPELINE_TRIGGER_SECRET


### PR DESCRIPTION
This way it is easier for users to see which branches are protected,
and also clearer how to change it. Also, it paves the way to allow
users to choose their own default in a future version of ODS when
those templates are applied via Tailor.

Related to https://github.com/opendevstack/ods-core/issues/107.