### PR TITLE
Feature/bix 545 improve sonarqube support on quickstarters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - New quickstarter `be-docker-plain`: useful for starting with a plain `Dockerfile` and no BE/FE framework on top ([#97](https://github.com/opendevstack/ods-project-quickstarters/issues/97))
 - Maven/Gradle Jenkins slave `jenkins-slave-maven` now gets Nexus credentials injected as server into `settings.xml` ([#127](https://github.com/opendevstack/ods-project-quickstarters/issues/127))
 - New quickstarter `ds_ml_service` for machine learning from model training & testing to production ([#111](https://github.com/opendevstack/ods-project-quickstarters/issues/111))
+- Quickstarter `fe-angular` now provides coverage analysis data to SonarQube and added SonarQube's linter rules for tslint
 - Documentation of all quickstarters and slaves added
 
 ### Changed

--- a/boilerplates/fe-angular/Jenkinsfile
+++ b/boilerplates/fe-angular/Jenkinsfile
@@ -20,7 +20,7 @@ library identifier: 'ods-library@production', retriever: modernSCM(
   eg. to create and set your own builder slave instead of 
   the node js slave used here - the code of the slave can be found at
   https://github.com/opendevstack/ods-project-quickstarters/tree/master/jenkins-slaves/nodejs8-angular
- */ 
+ */
 odsPipeline(
   image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular",
   projectId: projectId,
@@ -41,7 +41,9 @@ odsPipeline(
 def stageBuild(def context) {
   stage('Build') {
     withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_HOST=${context.nexusHost}"]) {
+      sh "yarn --version"
       sh "yarn install"
+      sh "yarn ng version"
       sh "yarn build"
     }
     sh "cp -r dist/${context.componentId} docker/dist"
@@ -49,13 +51,13 @@ def stageBuild(def context) {
 }
 
 def stageUnitTest(def context) {
-    stage('Unit Test') {
-      sh "yarn test -- --single-run --progress false"
-    }
+  stage('Unit Test') {
+    sh "yarn test"
+  }
 }
 
 def stageLint(def context) {
   stage('Lint') {
-    sh "npm run lint"
+    sh "yarn lint"
   }
 }

--- a/boilerplates/fe-angular/README.md
+++ b/boilerplates/fe-angular/README.md
@@ -72,7 +72,7 @@ The Jenkinsfile is provisioned with this quick starter to ease CI/CD process.
 In Jenkinsfile, there are various stages
   * stageBuild - Builds the application by running `yarn install`, `yarn build` command and copies output folder `dist` into `docker/dist` folder.
   * stageUnitTest - Runs unit test cases by executing command `yarn test`.
-  * stageLint - Runs `ng lint` profiler by running command `npm run lint`.
+  * stageLint - Runs `ng lint` profiler by running command `yarn lint`.
 
 ## Builder Slave used
 

--- a/boilerplates/fe-angular/build.sh
+++ b/boilerplates/fe-angular/build.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+# Please note: When updating to a newer Angular version, please also update
+# files under "./files" that overwrite generated ones
+# see details on bottom of "./init.sh"
 ANGULAR_CLI_VERSION=6.0.7
+
 JENKINS_SLAVE=cd/jenkins-slave-nodejs8-angular:latest
 
 while [[ $# -gt 1 ]]
@@ -37,7 +41,7 @@ sudo docker pull \
 
 sudo docker tag \
   ${OCP_DOCKER_REGISTRY}/${JENKINS_SLAVE} ${JENKINS_SLAVE}
-  
+
 sudo docker build \
   --rm \
   -t ng:latest -t ng:$ANGULAR_CLI_VERSION \

--- a/boilerplates/fe-angular/files/package.json
+++ b/boilerplates/fe-angular/files/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "$COMPONENT",
+  "version": "0.0.0",
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build --prod --build-optimizer --progress=false",
+    "test": "ng test --watch=false --progress=false --code-coverage",
+    "lint": "ng lint --type-check=true",
+    "e2e": "ng e2e"
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/animations": "^6.0.3",
+    "@angular/common": "^6.0.3",
+    "@angular/compiler": "^6.0.3",
+    "@angular/core": "^6.0.3",
+    "@angular/forms": "^6.0.3",
+    "@angular/http": "^6.0.3",
+    "@angular/platform-browser": "^6.0.3",
+    "@angular/platform-browser-dynamic": "^6.0.3",
+    "@angular/router": "^6.0.3",
+    "core-js": "^2.5.4",
+    "rxjs": "^6.0.0",
+    "zone.js": "^0.8.26"
+  },
+  "devDependencies": {
+    "@angular/compiler-cli": "^6.0.3",
+    "@angular-devkit/build-angular": "~0.6.6",
+    "@angular/cli": "~6.0.7",
+    "@angular/language-service": "^6.0.3",
+    "@types/jasmine": "~2.8.6",
+    "@types/jasminewd2": "~2.0.3",
+    "@types/node": "~8.9.4",
+    "codelyzer": "~4.2.1",
+    "jasmine-core": "~2.99.1",
+    "jasmine-spec-reporter": "~4.2.1",
+    "karma": "~1.7.1",
+    "karma-chrome-launcher": "~2.2.0",
+    "karma-coverage-istanbul-reporter": "~2.0.0",
+    "karma-jasmine": "~1.1.1",
+    "karma-jasmine-html-reporter": "^0.2.2",
+    "protractor": "~5.3.0",
+    "rxjs-tslint": "^0.1.6",
+    "ts-node": "~5.0.1",
+    "tslint-sonarts": "^1.9.0",
+    "tslint": "~5.9.1",
+    "typescript": "2.8.1"
+  }
+}

--- a/boilerplates/fe-angular/files/package.json
+++ b/boilerplates/fe-angular/files/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve",
     "build": "ng build --prod --build-optimizer --progress=false",
     "test": "ng test --watch=false --progress=false --code-coverage",
-    "lint": "ng lint --type-check=true",
+    "lint": "ng lint",
     "e2e": "ng e2e"
   },
   "private": true,

--- a/boilerplates/fe-angular/files/tslint.json
+++ b/boilerplates/fe-angular/files/tslint.json
@@ -1,0 +1,135 @@
+{
+  "extends": ["tslint-sonarts"],
+  "rulesDirectory": [
+    "node_modules/codelyzer",
+    "node_modules/rxjs-tslint"
+  ],
+  "rules": {
+    "arrow-return-shorthand": true,
+    "callable-types": true,
+    "class-name": true,
+    "cognitive-complexity": true,
+    "comment-format": [
+      true,
+      "check-space"
+    ],
+    "curly": true,
+    "deprecation": {
+      "severity": "warn"
+    },
+    "eofline": true,
+    "forin": true,
+    "import-blacklist": [
+      true,
+      "rxjs/Rx"
+    ],
+    "import-spacing": true,
+    "indent": [
+      true,
+      "spaces"
+    ],
+    "interface-over-type-literal": true,
+    "label-position": true,
+    "max-line-length": [
+      true,
+      140
+    ],
+    "member-access": false,
+    "member-ordering": [
+      true,
+      {
+        "order": [
+          "static-field",
+          "instance-field",
+          "static-method",
+          "instance-method"
+        ]
+      }
+    ],
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-commented-code": false,
+    "no-console": [
+      true,
+      "debug",
+      "info",
+      "time",
+      "timeEnd",
+      "trace"
+    ],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-string": false,
+    "no-duplicate-super": true,
+    "no-empty": false,
+    "no-empty-interface": true,
+    "no-eval": true,
+    "no-inferrable-types": [
+      true,
+      "ignore-params"
+    ],
+    "no-misused-new": true,
+    "no-non-null-assertion": true,
+    "no-shadowed-variable": true,
+    "no-string-literal": false,
+    "no-string-throw": true,
+    "no-switch-case-fall-through": true,
+    "no-trailing-whitespace": true,
+    "no-unnecessary-initializer": true,
+    "no-unused-expression": true,
+    "no-use-before-declare": true,
+    "no-var-keyword": true,
+    "object-literal-sort-keys": false,
+    "one-line": [
+      true,
+      "check-open-brace",
+      "check-catch",
+      "check-else",
+      "check-whitespace"
+    ],
+    "prefer-const": true,
+    "quotemark": [
+      true,
+      "single"
+    ],
+    "radix": true,
+    "semicolon": [
+      true,
+      "always"
+    ],
+    "triple-equals": [
+      true,
+      "allow-null-check"
+    ],
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      }
+    ],
+    "unified-signatures": true,
+    "variable-name": false,
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-separator",
+      "check-type"
+    ],
+    "no-output-on-prefix": true,
+    "use-input-property-decorator": true,
+    "use-output-property-decorator": true,
+    "use-host-property-decorator": true,
+    "no-input-rename": true,
+    "no-output-rename": true,
+    "use-life-cycle-interface": true,
+    "use-pipe-transform-interface": true,
+    "component-class-suffix": true,
+    "directive-class-suffix": true
+  }
+}

--- a/boilerplates/fe-angular/files/tslint.json
+++ b/boilerplates/fe-angular/files/tslint.json
@@ -5,15 +5,11 @@
     "node_modules/rxjs-tslint"
   ],
   "rules": {
-    "arrow-return-shorthand": true,
-    "callable-types": true,
-    "class-name": true,
     "cognitive-complexity": true,
     "comment-format": [
       true,
       "check-space"
     ],
-    "curly": true,
     "deprecation": {
       "severity": "warn"
     },
@@ -28,7 +24,6 @@
       true,
       "spaces"
     ],
-    "interface-over-type-literal": true,
     "label-position": true,
     "max-line-length": [
       true,
@@ -62,7 +57,6 @@
     "no-duplicate-string": false,
     "no-duplicate-super": true,
     "no-empty": false,
-    "no-empty-interface": true,
     "no-eval": true,
     "no-inferrable-types": [
       true,
@@ -70,10 +64,8 @@
     ],
     "no-misused-new": true,
     "no-non-null-assertion": true,
-    "no-shadowed-variable": true,
     "no-string-literal": false,
     "no-string-throw": true,
-    "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
     "no-unnecessary-initializer": true,
     "no-unused-expression": true,

--- a/boilerplates/fe-angular/init.sh
+++ b/boilerplates/fe-angular/init.sh
@@ -74,6 +74,19 @@ repo_path=$(echo "$GROUP" | tr . /)
 sed -i.bak "s|org/opendevstack/projectId|$repo_path|g" $SCRIPT_DIR/files/docker/Dockerfile
 rm $SCRIPT_DIR/files/docker/Dockerfile.bak
 
+# The following commands copy custom files over the generated ones from the call
+# of "ng new" above. The custom files were created based on the generated ones
+# and the following changes:
+#   - package.json:
+#       - replaced value of "name" with placeholder "$COMPONENT"
+#       - added parameters to the commands in "scripts"
+#       - added "devDependencies" for "rxjs-tslint" and "tslint-sonarts"
+#   - tslint.json:
+#       - added linter rules from "rxjs-tslint" and "tslint-sonarts"
+#       - explicitly mention or disable some of the stricter SonarQube rules:
+#         "cognitive-complexity", "no-commented-code", "no-duplicate-string"
+#
+# Please note: When updating to a newer Angular version, please update those files accordingly.
 echo "copy custom files from quickstart to generated project"
 rm ./package.json
 rm ./tslint.json

--- a/boilerplates/fe-angular/init.sh
+++ b/boilerplates/fe-angular/init.sh
@@ -78,4 +78,4 @@ echo "copy custom files from quickstart to generated project"
 rm ./package.json
 rm ./tslint.json
 cp -rv $SCRIPT_DIR/files/. .
-sed -i -e "s/\$COMPONENT/${COMPONENT}/" ./package.json
+sed -i "s/\$COMPONENT/${COMPONENT}/" ./package.json

--- a/boilerplates/fe-angular/init.sh
+++ b/boilerplates/fe-angular/init.sh
@@ -33,9 +33,6 @@ cd $COMPONENT
 
 sudo chown -R $OWNER .
 
-# Change typescript version to 2.8.0 as a workaround for https://github.com/ReactiveX/rxjs/issues/4512
-sed -i -e 's|\(.*"typescript"\): "\(.*\)"\(.*\)|\1: '"\"2.8.1\"\3|" ./package.json
-
 echo "Configure headless chrome in karma.conf.j2"
 read -r -d "" CHROME_CONFIG << EOM || true
     browsers: \['ChromeNoSandboxHeadless'\],\\
@@ -78,4 +75,7 @@ sed -i.bak "s|org/opendevstack/projectId|$repo_path|g" $SCRIPT_DIR/files/docker/
 rm $SCRIPT_DIR/files/docker/Dockerfile.bak
 
 echo "copy custom files from quickstart to generated project"
+rm ./package.json
+rm ./tslint.json
 cp -rv $SCRIPT_DIR/files/. .
+sed -i -e "s/\$COMPONENT/${COMPONENT}/" ./package.json

--- a/boilerplates/fe-angular/sonar-project.properties
+++ b/boilerplates/fe-angular/sonar-project.properties
@@ -7,8 +7,17 @@ sonar.projectName=@project_id@-@component_id@
 # Comma-separated paths to directories with sources (required)
 sonar.sources=src
 
-# Forced Language (optional)
-sonar.language=js
+# Forced Language: type script
+sonar.language=ts
 
 # Encoding of the source files (optional but recommended as default is ASCII)
 sonar.sourceEncoding=UTF-8
+
+# Exclude test files from coverage analysis
+sonar.coverage.exclusions=**/*.spec.ts
+
+# Exclude non type script files from coverage analysis
+sonar.exclusions=**/*.html,**/*.scss,**/*.json,**/*.ico,**/*.svg
+
+# Define coverage information inside the Angular project
+sonar.typescript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
Improve SonarQube support for fe-angular quickstarter by
* creating coverage analysis data
* publishing coverage analysis data towards SonarQube
* integrating SonarQube-specific TSLint rules for an early check during ```ng lint```

other changes:
* providing a separate ```package.json``` file for overwriting instead of transforming the generated one
* fully switch the quickstarter to use yarn
* move build parameters from ```Jenkinsfile``` into ```package.json```

relates to #212 