### PR TITLE
Update memory requests/limits

### DIFF
--- a/ocp-templates/templates/cd-jenkins-master.yml
+++ b/ocp-templates/templates/cd-jenkins-master.yml
@@ -158,7 +158,7 @@ objects:
             limits:
               memory: '${MEMORY_LIMIT}'
             requests:
-              memory: 100Mi
+              memory: '${MEMORY_REQUEST}'
           securityContext:
             capabilities: {}
             privileged: false
@@ -254,6 +254,8 @@ parameters:
   value: "true"
 - name: MEMORY_LIMIT
   value: 2Gi
+- name: MEMORY_REQUEST
+  value: 1Gi
 - name: VOLUME_CAPACITY
   value: 5Gi
 - name: NAMESPACE

--- a/ocp-templates/templates/component-environment.yml
+++ b/ocp-templates/templates/component-environment.yml
@@ -133,12 +133,12 @@ parameters:
   - name: MEMORY_LIMIT
     displayName: Memory Limit
     description: Maximum amount of memory available for the container.
-    value: 600Mi
+    value: 512Mi
     required: true
   - name: MEMORY_REQUEST
     displayName: Memory Request
     description: Minimum amount of memory requested for the container.
-    value: 400Mi
+    value: 256Mi
     required: true
 labels:
   template: component-template

--- a/ocp-templates/templates/component-environment.yml
+++ b/ocp-templates/templates/component-environment.yml
@@ -94,7 +94,7 @@ objects:
                 limits:
                   memory: '${MEMORY_LIMIT}'
                 requests:
-                  memory: 100Mi
+                  memory: '${MEMORY_REQUEST}'
               terminationMessagePath: /dev/termination-log
           dnsPolicy: ClusterFirst
           restartPolicy: Always
@@ -132,8 +132,13 @@ parameters:
     required: true
   - name: MEMORY_LIMIT
     displayName: Memory Limit
-    description: Maxiroutemum amount of memory the Node.js container can use.
-    value: 1024Mi
+    description: Maximum amount of memory available for the container.
+    value: 600Mi
+    required: true
+  - name: MEMORY_REQUEST
+    displayName: Memory Request
+    description: Minimum amount of memory requested for the container.
+    value: 400Mi
     required: true
 labels:
   template: component-template


### PR DESCRIPTION
The default ratio was 10, which is quite high. This will lead OpenShift to oversubscribe the nodes to 10x their capacity. This can cause unexpected OOMKill events, and very large high load induced instability in the entire cluster. Therefore, it is better to reduce the ratio (here to 1.5x).

I would love to reduce the default requested amount, but some quickstarters consume quite a lot of memory, so we need a high default. Maybe in the future, we can allow every quickstarter to choose this value individually (e.g. the frontend components running only Nginx need far less).

Closes #277.