### PR TITLE
Access keyserver using port 80

### DIFF
--- a/boilerplates/rshiny-app/docker/Dockerfile
+++ b/boilerplates/rshiny-app/docker/Dockerfile
@@ -25,7 +25,7 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 
 # Add CRAN apt repo
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
     echo 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu xenial/' > /etc/apt/sources.list.d/cran.list
 
 # Add Cloudera apt repo


### PR DESCRIPTION
Standard port 11371 is often blocked by company firewalls / proxy.
Use port 80 instead

fixes #298 