### PR TITLE
Install java-11-openjdk

### DIFF
--- a/boilerplates/be-springboot/files/docker/Dockerfile
+++ b/boilerplates/be-springboot/files/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM adoptopenjdk/openjdk11:alpine-jre
 
 COPY app.jar app.jar
 

--- a/boilerplates/be-springboot/templates/build-4.10.gradle
+++ b/boilerplates/be-springboot/templates/build-4.10.gradle
@@ -22,7 +22,7 @@ apply plugin: 'io.spring.dependency-management'
 
 group = '__GROUP__'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '1.8'
+sourceCompatibility = JavaVersion.VERSION_11
 
 repositories {
 	maven () {

--- a/jenkins-slaves/maven/Dockerfile.rhel7
+++ b/jenkins-slaves/maven/Dockerfile.rhel7
@@ -23,16 +23,21 @@ ENV MAVEN_VERSION=3.3 \
 ENV JAVA_HOME=/usr/lib/jvm/jre
 
 # Install Maven
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
-    # yum-config-manager --disable epel >/dev/null || : && \
-    yum install -y wget && \
-    alternatives --set java $(alternatives --display java | awk '/family.*x86_64/ { print $1; }') && \
-	wget https://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo && \
-	sed -i s/\$releasever/6/g /etc/yum.repos.d/epel-apache-maven.repo && \
-    INSTALL_PKGS="java-1.8.0-openjdk-devel.x86_64 apache-maven*" && \
-	yum install -y $INSTALL_PKGS && \
+RUN yum install -y wget && \
+    wget https://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo && \
+    sed -i s/\$releasever/6/g /etc/yum.repos.d/epel-apache-maven.repo && \
+    INSTALL_PKGS="java-11-openjdk-devel apache-maven*" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum clean all -y && \
-    mkdir -p $HOME/.m2
+    mkdir -p $HOME/.m2 && \
+    exactVersion=$(ls -lah /usr/lib/jvm | grep java-11-openjdk-11 | awk '{print $NF}' | head -1) && \
+    alternatives --set java /usr/lib/jvm/${exactVersion}/bin/java && \
+    alternatives --set javac /usr/lib/jvm/${exactVersion}/bin/javac && \
+    java -version && \
+    javac -version
+
+# Container support is now integrated in Java 11, the +UseCGroupMemoryLimitForHeap option has been pruned
+ENV JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true"
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable


### PR DESCRIPTION
I propose to make Java 11 the default for the ODS 1.2 slave. This should not break existing Java 8 applications.

In any case, we should think about versioning / tagging of slaves. I propose to do the same as with the shared library: from tags/branches we point to the corresponding tag ... as in, a `Jenkinsfile` in the `1.2.x` branch should point to a slave with tag `1.2.x` to avoid upgrade problems.

Closes #309 