### PR TITLE
changing build pods to terminating type

### DIFF
--- a/ocp-templates/ocp-config/component-environment/component-template.yml
+++ b/ocp-templates/ocp-config/component-environment/component-template.yml
@@ -34,6 +34,7 @@ objects:
     metadata:
       name: ${COMPONENT}
     spec:
+      completionDeadlineSeconds: ${COMPLETION_DEADLINE_SECONDS}
       failedBuildsHistoryLimit: 5
       nodeSelector: null
       output:
@@ -137,3 +138,9 @@ parameters:
     description: The version to be used.
     value: latest
     required: true
+  - name: COMPLETION_DEADLINE_SECONDS
+    displayName: Completion Deadline Seconds
+    description: how long the docker build of the component can last before it is canceled
+    value: "1800"
+    required: true
+


### PR DESCRIPTION
... so they are not covered by non-terminating quota scope

By adding a

     spec:
        completionDeadlineSeconds: 1800

the build pod becomes a "terminating" type container and a quota targeting non-terminating containers does no longer apply.

fixes #319 