### PR TITLE
restore backward compatible script oc container

### DIFF
--- a/ocp-templates/Dockerfile
+++ b/ocp-templates/Dockerfile
@@ -4,9 +4,7 @@ MAINTAINER "Andreas Bellmann" <andreas.bellmann@opitz-consulting.com>
 
 RUN oc version
 
-WORKDIR /data/ods-project-quickstarters/ocp-templates/scripts
-COPY ods-project-quickstarters/ocp-templates/scripts    /data/ods-project-quickstarters/ocp-templates/scripts
-COPY ods-project-quickstarters/ocp-templates/ocp-config /data/ods-project-quickstarters/ocp-templates/ocp-config
-COPY ods-configuration                                  /data/ods-configuration
+WORKDIR /data
+COPY scripts /data/
 
 ENTRYPOINT [""]

--- a/ocp-templates/Dockerfile-with-config
+++ b/ocp-templates/Dockerfile-with-config
@@ -1,0 +1,12 @@
+FROM cd/jenkins-slave-base
+
+MAINTAINER "Andreas Bellmann" <andreas.bellmann@opitz-consulting.com>
+
+RUN oc version
+
+WORKDIR /data/ods-project-quickstarters/ocp-templates/scripts
+COPY ods-project-quickstarters/ocp-templates/scripts    /data/ods-project-quickstarters/ocp-templates/scripts
+COPY ods-project-quickstarters/ocp-templates/ocp-config /data/ods-project-quickstarters/ocp-templates/ocp-config
+COPY ods-configuration                                  /data/ods-configuration
+
+ENTRYPOINT [""]

--- a/rundeck-jobs/openshift/create-component.yaml
+++ b/rundeck-jobs/openshift/create-component.yaml
@@ -62,14 +62,14 @@
         cp -r           ods-project-quickstarters/ocp-templates/ocp-config docker/ods-project-quickstarters/ocp-templates
         mkdir -p docker/ods-project-quickstarters/ocp-templates/scripts
         cp -r           ods-project-quickstarters/ocp-templates/scripts docker/ods-project-quickstarters/ocp-templates
-        cp ods-project-quickstarters/ocp-templates/Dockerfile docker/
+        cp ods-project-quickstarters/ocp-templates/Dockerfile-with-config docker/
         cd docker
-        sudo docker build --build-arg OC_IP=@globals.openshift_apihost_lookup@ -t oc .
+        sudo docker build -f Dockerfile-with-config --build-arg OC_IP=@globals.openshift_apihost_lookup@ -t oc-cfg .
     - description: create openshift components within projects
       script: |-
         echo "Token --> @option.openshift_api_token@"
         cd "/tmp/rundeck_@job.id@_@job.execid@/ods-project-quickstarters/ocp-templates"
-        sudo docker run --rm oc /bin/bash -c 'oc login @globals.openshift_apihost@ --token=@option.openshift_api_token@ && oc project cd && ./create-component.sh -p @option.project_id@ -c "@option.component_id@" -r @option.route@ -ne "@globals.nexus_host@"'
+        sudo docker run --rm oc-cfg /bin/bash -c 'oc login @globals.openshift_apihost@ --token=@option.openshift_api_token@ && oc project cd && ./create-component.sh -p @option.project_id@ -c "@option.component_id@" -r @option.route@ -ne "@globals.nexus_host@"'
     keepgoing: false
     strategy: node-first
   uuid: d905990c-3b74-4a27-9d49-8a63c0a6989f

--- a/rundeck-jobs/openshift/create-projects.yaml
+++ b/rundeck-jobs/openshift/create-projects.yaml
@@ -51,14 +51,14 @@
         cp -r           ods-project-quickstarters/ocp-templates/ocp-config docker/ods-project-quickstarters/ocp-templates
         mkdir -p docker/ods-project-quickstarters/ocp-templates/scripts
         cp -r           ods-project-quickstarters/ocp-templates/scripts docker/ods-project-quickstarters/ocp-templates
-        cp ods-project-quickstarters/ocp-templates/Dockerfile docker/
+        cp ods-project-quickstarters/ocp-templates/Dockerfile-with-config docker/
         cd docker
-        sudo docker build --build-arg OC_IP=@globals.openshift_apihost_lookup@ -t oc .
+        sudo docker build -f Dockerfile-with-config --build-arg OC_IP=@globals.openshift_apihost_lookup@ -t oc-cfg .
     - description: create openshift projects (dev / test / cd with jenkins)
       script: |-
         set -eux
         cd "/tmp/rundeck_@job.id@_@job.execid@/ods-project-quickstarters/ocp-templates"
-        sudo docker run --rm oc /bin/bash -c 'oc login @globals.openshift_apihost@ --token=@option.openshift_api_token@ && ./create-projects.sh -p @option.project_id@ -n @globals.nexus_host@ -a @option.project_admin@ -e @option.project_groups@'
+        sudo docker run --rm oc-cfg /bin/bash -c 'oc login @globals.openshift_apihost@ --token=@option.openshift_api_token@ && ./create-projects.sh -p @option.project_id@ -n @globals.nexus_host@ -a @option.project_admin@ -e @option.project_groups@'
     keepgoing: false
     strategy: node-first
   uuid: 00f767ef-347f-480e-8ad3-bf2aed3abf5d

--- a/rundeck-jobs/openshift/create-rshiny.yaml
+++ b/rundeck-jobs/openshift/create-rshiny.yaml
@@ -56,14 +56,14 @@
         cp -r           ods-project-quickstarters/ocp-templates/ocp-config docker/ods-project-quickstarters/ocp-templates
         mkdir -p docker/ods-project-quickstarters/ocp-templates/scripts
         cp -r           ods-project-quickstarters/ocp-templates/scripts docker/ods-project-quickstarters/ocp-templates
-        cp ods-project-quickstarters/ocp-templates/Dockerfile docker/
+        cp ods-project-quickstarters/ocp-templates/Dockerfile-with-config docker/
         cd docker
-        sudo docker build --build-arg OC_IP=@globals.openshift_apihost_lookup@ -t oc .
+        sudo docker build -f Dockerfile-with-config --build-arg OC_IP=@globals.openshift_apihost_lookup@ -t oc-cfg .
     - description: create openshift rshiny app cd project
       script: |-
         set -eux
         cd "/tmp/rundeck_@job.id@_@job.execid@/ods-project-quickstarters/ocp-templates"
-        sudo docker run --rm oc /bin/bash -c 'oc login @globals.openshift_apihost@ --token=@option.openshift_api_token@ && oc project cd && ./create-rshiny-app.sh -p @option.project_id@ -c "@option.component_id@" '
+        sudo docker run --rm oc-cfg /bin/bash -c 'oc login @globals.openshift_apihost@ --token=@option.openshift_api_token@ && oc project cd && ./create-rshiny-app.sh -p @option.project_id@ -c "@option.component_id@" '
     keepgoing: false
     strategy: node-first
   uuid: ba36276e-5018-47b7-8f3f-9ec8e648d04f

--- a/rundeck-jobs/quickstarts/ds_ml_service.yaml
+++ b/rundeck-jobs/quickstarts/ds_ml_service.yaml
@@ -66,11 +66,11 @@
         cp -r           ods-project-quickstarters/ocp-templates/ocp-config docker/ods-project-quickstarters/ocp-templates
         mkdir -p docker/ods-project-quickstarters/ocp-templates/scripts
         cp -r           ods-project-quickstarters/ocp-templates/scripts docker/ods-project-quickstarters/ocp-templates
-        cp ods-project-quickstarters/ocp-templates/Dockerfile docker/
+        cp ods-project-quickstarters/ocp-templates/Dockerfile-with-config docker/
         cd docker
-        sudo docker build --build-arg OC_IP=@globals.openshift_apihost_lookup@ -t oc .
+        sudo docker build -f Dockerfile-with-config --build-arg OC_IP=@globals.openshift_apihost_lookup@ -t oc-cfg .
     - description: create components
-      exec: echo "Token --> ${option.openshift_api_token}" && cd /tmp/rundeck_${job.id}_${job.execid}/ods-project-quickstarters/ocp-templates  && sudo docker run --rm oc /bin/bash -c 'oc login ${globals.openshift_apihost} --token=${option.openshift_api_token} && oc project cd && ./custom-create-components.sh -p ${option.project_id} -c "${option.component_id}" -b "${option.git_url_http}" -ne "${globals.nexus_host}"'
+      exec: echo "Token --> ${option.openshift_api_token}" && cd /tmp/rundeck_${job.id}_${job.execid}/ods-project-quickstarters/ocp-templates  && sudo docker run --rm oc-cfg /bin/bash -c 'oc login ${globals.openshift_apihost} --token=${option.openshift_api_token} && oc project cd && ./custom-create-components.sh -p ${option.project_id} -c "${option.component_id}" -b "${option.git_url_http}" -ne "${globals.nexus_host}"'
     - description: add Jenkinsfile to generated project
       script: |-
         sudo chown @globals.rundeck_os_user@ -R /tmp/rundeck_@job.id@_@job.execid@/@option.component_id@


### PR DESCRIPTION
- keep old way to build oc intact
- use Dockerfile-with-config and tag container oc-cfg
  which use the container with the config embedded.

fixes #350 