### PR TITLE
prepare jenkins slaves for 1.2.x release

### DIFF
--- a/jenkins-slaves/nodejs10-angular/Dockerfile.rhel7
+++ b/jenkins-slaves/nodejs10-angular/Dockerfile.rhel7
@@ -35,7 +35,7 @@ RUN yum -y install /root/google-chrome-stable_current_x86_64.rpm && \
 # Install cypress dependencies
 # Please note: xorg-x11-server-Xvfb is not available on RHEL via yum anymore, so "RUN yum install -y xorg-x11-server-Xvfb" won't work.
 #   Therefore this Dockerfile uses the version from CentOS instead.
-ADD http://mirror.centos.org/centos/7/os/x86_64/Packages/xorg-x11-server-Xvfb-1.20.4-7.el7.x86_64.rpm /root/xorg-x11-server-Xvfb.x86_64.rpm
+ADD http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/xorg-x11-server-Xvfb-1.20.4-7.el7.x86_64.rpm /root/xorg-x11-server-Xvfb.x86_64.rpm
 RUN yum install -y /root/xorg-x11-server-Xvfb.x86_64.rpm && \
     yum install -y gtk2-2.24* && \
     yum install -y libXtst* && \

--- a/jenkins-slaves/nodejs10-angular/Dockerfile.rhel7
+++ b/jenkins-slaves/nodejs10-angular/Dockerfile.rhel7
@@ -23,7 +23,7 @@ ENV NODEJS_VERSION=8.11 \
 RUN yum-config-manager --enable rhel-7-server-extras-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum makecache
- 
+
 ADD https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm /root/google-chrome-stable_current_x86_64.rpm
 RUN yum -y install redhat-lsb libXScrnSaver
 RUN yum -y install /root/google-chrome-stable_current_x86_64.rpm && \
@@ -35,7 +35,7 @@ RUN yum -y install /root/google-chrome-stable_current_x86_64.rpm && \
 # Install cypress dependencies
 # Please note: xorg-x11-server-Xvfb is not available on RHEL via yum anymore, so "RUN yum install -y xorg-x11-server-Xvfb" won't work.
 #   Therefore this Dockerfile uses the version from CentOS instead.
-ADD http://mirror.centos.org/centos/7/os/x86_64/Packages/xorg-x11-server-Xvfb-1.20.1-3.el7.x86_64.rpm /root/xorg-x11-server-Xvfb.x86_64.rpm
+ADD http://mirror.centos.org/centos/7/os/x86_64/Packages/xorg-x11-server-Xvfb-1.20.4-7.el7.x86_64.rpm /root/xorg-x11-server-Xvfb.x86_64.rpm
 RUN yum install -y /root/xorg-x11-server-Xvfb.x86_64.rpm && \
     yum install -y gtk2-2.24* && \
     yum install -y libXtst* && \

--- a/jenkins-slaves/nodejs8-angular/Dockerfile.rhel7
+++ b/jenkins-slaves/nodejs8-angular/Dockerfile.rhel7
@@ -35,7 +35,7 @@ RUN yum -y install /root/google-chrome-stable_current_x86_64.rpm && \
 # Install cypress dependencies
 # Please note: xorg-x11-server-Xvfb is not available on RHEL via yum anymore, so "RUN yum install -y xorg-x11-server-Xvfb" won't work.
 #   Therefore this Dockerfile uses the version from CentOS instead.
-ADD http://mirror.centos.org/centos/7/os/x86_64/Packages/xorg-x11-server-Xvfb-1.20.4-7.el7.x86_64.rpm /root/xorg-x11-server-Xvfb.x86_64.rpm
+ADD http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/xorg-x11-server-Xvfb-1.20.4-7.el7.x86_64.rpm /root/xorg-x11-server-Xvfb.x86_64.rpm
 RUN yum install -y /root/xorg-x11-server-Xvfb.x86_64.rpm && \
     yum install -y gtk2-2.24* && \
     yum install -y libXtst* && \

--- a/jenkins-slaves/nodejs8-angular/Dockerfile.rhel7
+++ b/jenkins-slaves/nodejs8-angular/Dockerfile.rhel7
@@ -23,7 +23,7 @@ ENV NODEJS_VERSION=8.11 \
 RUN yum-config-manager --enable rhel-7-server-extras-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum makecache
- 
+
 ADD https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm /root/google-chrome-stable_current_x86_64.rpm
 RUN yum -y install redhat-lsb libXScrnSaver
 RUN yum -y install /root/google-chrome-stable_current_x86_64.rpm && \
@@ -35,7 +35,7 @@ RUN yum -y install /root/google-chrome-stable_current_x86_64.rpm && \
 # Install cypress dependencies
 # Please note: xorg-x11-server-Xvfb is not available on RHEL via yum anymore, so "RUN yum install -y xorg-x11-server-Xvfb" won't work.
 #   Therefore this Dockerfile uses the version from CentOS instead.
-ADD http://mirror.centos.org/centos/7/os/x86_64/Packages/xorg-x11-server-Xvfb-1.20.1-3.el7.x86_64.rpm /root/xorg-x11-server-Xvfb.x86_64.rpm
+ADD http://mirror.centos.org/centos/7/os/x86_64/Packages/xorg-x11-server-Xvfb-1.20.4-7.el7.x86_64.rpm /root/xorg-x11-server-Xvfb.x86_64.rpm
 RUN yum install -y /root/xorg-x11-server-Xvfb.x86_64.rpm && \
     yum install -y gtk2-2.24* && \
     yum install -y libXtst* && \
@@ -53,7 +53,7 @@ RUN yum install -y /root/xorg-x11-server-Xvfb.x86_64.rpm && \
 # installation details see: https://www.softwarecollections.org/en/
 # and the base image relies on scl_enable
 COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
-	
+
 RUN curl --silent --location https://rpm.nodesource.com/setup_8.x | bash - && \
     yum install -y nodejs && \
     yum install -y gcc-c++ make && \

--- a/jenkins-slaves/python/Dockerfile.rhel7
+++ b/jenkins-slaves/python/Dockerfile.rhel7
@@ -3,7 +3,7 @@ FROM cd/jenkins-slave-base
 MAINTAINER Michael Sauter <michael.sauter@boehringer-ingelheim.com>
 
 ENV PYTHON_VERSION=3.6.0
-ENV INSTALL_PKGS="yum-utils groupinstall development gcc make openssl-devel zlib-devel"
+ENV INSTALL_PKGS="yum-utils gcc make openssl-devel zlib-devel"
 
 RUN set -x \
     && yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
@@ -31,7 +31,7 @@ RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" \
 RUN pip3 install --upgrade pip \
     && pip3 -V \
     && pip3 install virtualenv pycodestyle
-        
+
 # Configure PIP SSL validation
 RUN pip config set global.cert /etc/ssl/certs/ca-bundle.crt \
     && pip config list


### PR DESCRIPTION
update version of xvfb for nodejs slaves and cleanup dependency packages on python flask slave
closes #356 