### PR TITLE
fe-react: Fix env var that define where test reports are generated

### DIFF
--- a/boilerplates/fe-react/Jenkinsfile
+++ b/boilerplates/fe-react/Jenkinsfile
@@ -50,7 +50,7 @@ def stageBuild(def context) {
 def stageUnitTest(def context) {
   try {
     stage('Unit Test') {
-    sh "JEST_JUNIT_OUTPUT='build/test-results/test/test-results.xml' CI=true npm test -- --reporters=default --reporters=jest-junit"
+    	sh "JEST_JUNIT_OUTPUT_DIR='build/test-results/test' JEST_JUNIT_OUTPUT_NAME='test-results.xml' CI=true npm test -- --reporters=default --reporters=jest-junit"
     }
   } finally {
     junit 'build/test-results/test/test-results.xml'


### PR DESCRIPTION
Fix for https://github.com/opendevstack/ods-project-quickstarters/issues/364