### PR TITLE
Avoid disclosure of credentials

### DIFF
--- a/boilerplates/be-springboot/init.sh
+++ b/boilerplates/be-springboot/init.sh
@@ -60,6 +60,7 @@ echo "gradle version: $version"
 USE_LEGACY_NEXUS_UPLOAD_SCRIPT=0
 
 if [[ $version == "4.9" ]]; then
+	set +x # avoid disclosure passwords/tokens
 	sed -i.bak '/springBootVersion =/a \
 	    nexus_url = "\${project.findProperty("nexus_url") ?: System.getenv("NEXUS_HOST")}"\
 	    nexus_folder = "candidates"\
@@ -97,6 +98,7 @@ if [[ $version == "4.9" ]]; then
 	        }\
 	      }\
 	/g' build.gradle
+	set -x
 	USE_LEGACY_NEXUS_UPLOAD_SCRIPT=1
 else
 	templateFile=$SCRIPT_DIR/templates/build-$version.gradle

--- a/boilerplates/ds-ml-service/custom-create-components.sh
+++ b/boilerplates/ds-ml-service/custom-create-components.sh
@@ -120,13 +120,19 @@ for devenv in dev test ; do
         # create component environment variables
         echo "--> setting environment variables for component type ${type} in env ${devenv}";
         if [ ${type} = "training-service" ]; then
+            set +x # avoid disclosure of passwords/tokens
+            echo creating secret ${COMPONENT}-training-secret
             oc create secret generic ${COMPONENT}-training-secret --from-literal=username=${COMPONENT}-training-username --from-literal=password=`dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64  | rev | cut -b 2- | rev | tr -cd '[:alnum:]'` -n ${PROJECT}-${devenv}
+            set -x
             oc set triggers dc/${COMPONENT}-${type} --from-config --remove -n ${PROJECT}-${devenv}
             oc set env dc/${COMPONENT}-${type} --env=DSI_EXECUTE_ON=LOCAL -n ${PROJECT}-${devenv}
             oc set env dc/${COMPONENT}-${type} --from=secret/${COMPONENT}-training-secret --prefix=DSI_TRAINING_SERVICE_ -n ${PROJECT}-${devenv}
             oc set triggers dc/${COMPONENT}-${type} --from-config -n ${PROJECT}-${devenv}
         else
+            set +x # avoid disclosure of passwords/tokens
+            echo creating secret ${COMPONENT}-prediction-secret
             oc create secret generic ${COMPONENT}-prediction-secret --from-literal=username=${COMPONENT}-prediction-username --from-literal=password=`dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64  | rev | cut -b 2- | rev | tr -cd '[:alnum:]'` -n ${PROJECT}-${devenv}
+            set -x
             oc set triggers dc/${COMPONENT}-${type} --from-config --remove -n ${PROJECT}-${devenv}
             oc set env dc/${COMPONENT}-${type} --env=DSI_TRAINING_BASE_URL=http://${COMPONENT}-training-service.${PROJECT}-${devenv}.svc:8080 -n ${PROJECT}-${devenv}
             oc set env dc/${COMPONENT}-${type} --from=secret/${COMPONENT}-training-secret --prefix=DSI_TRAINING_SERVICE_ -n ${PROJECT}-${devenv}

--- a/ocp-templates/scripts/clone-project.sh
+++ b/ocp-templates/scripts/clone-project.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -ex
+set -e
+# removing option -x to avoid disclosure of passwords/tokens
 
 usage() {
     echo "usage: sh $0 -p <project id> -o <openshift host> -b <bitbucket host> -c <http basic auth credentials \
@@ -80,7 +81,7 @@ echo "Provided params: \
 - PROJECT_ID: $PROJECT_ID \
 - OPENSHIFT_HOST: $OPENSHIFT_HOST \
 - BITBUCKET_HOST: $BITBUCKET_HOST \
-- CREDENTIALS: **** \
+- CREDENTIALS: <blinded> \
 - SOURCE_ENV: $SOURCE_ENV \
 - TARGET_ENV: $TARGET_ENV"
 

--- a/ocp-templates/scripts/create-projects.sh
+++ b/ocp-templates/scripts/create-projects.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -ex
+set -e
+# Not using -x (tracing) to avoid disclosure of passwords/tokens when
+# processing unknown arguments.
 
 # This script creates the 3 OCP projects we currently require for every
 # OD project.
@@ -41,6 +43,8 @@ case $key in
 esac
 shift # past argument or value
 done
+
+set -x  # no passwords/tokens are used below
 
 # check required parameters
 if [ -z ${PROJECT+x} ]; then

--- a/ocp-templates/scripts/export_ocp_project_metadata.sh
+++ b/ocp-templates/scripts/export_ocp_project_metadata.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -e
+# Not using -x (tracing) to avoid disclosure of passwords/tokens when
+# processing arguments.
 
 # this script exports project templates for OpenDevStack in OpenShift
 #
@@ -180,11 +182,6 @@ else
 	echo "git url: ${OD_GIT_URL}"
 fi
 
-# Enable debug mode
-if [[ $OD_VERBOSE != "" ]]; then
-  set -x
-fi
-
 project_name=$OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG
 local_git_repo_fld=${project_name}-occonfig-artifacts
 
@@ -198,6 +195,11 @@ else
       echo "ERROR: could not login into ${OD_OCP_SOURCE_HOST} with oc"
       exit 1
   fi
+fi
+
+# Enable tracing only after token would be disclosed
+if [[ $OD_VERBOSE != "" ]]; then
+  set -x
 fi
 
 # checkout git repo (standard naming)

--- a/rundeck-jobs/common/verify global rundeck settings.yaml
+++ b/rundeck-jobs/common/verify global rundeck settings.yaml
@@ -16,7 +16,7 @@
   sequence:
     commands:
     - description: echo input parameters
-      exec: 'echo openshift_api_token: bb${option.openshift_api_token}bb host: ${globals.openshift_apihost}'
+      exec: 'echo "openshift_api_token: <blinded> host: ${globals.openshift_apihost}"'
     - description: verify openshift registry access
       exec: sudo docker login -u ${globals.openshift_user} -p ${option.openshift_api_token} ${globals.openshift_dockerregistry}
     - description: Pull and tag jenkins slave

--- a/rundeck-jobs/openshift/create-component.yaml
+++ b/rundeck-jobs/openshift/create-component.yaml
@@ -67,7 +67,6 @@
         sudo docker build -f Dockerfile-with-config --build-arg OC_IP=@globals.openshift_apihost_lookup@ -t oc-cfg .
     - description: create openshift components within projects
       script: |-
-        echo "Token --> @option.openshift_api_token@"
         cd "/tmp/rundeck_@job.id@_@job.execid@/ods-project-quickstarters/ocp-templates"
         sudo docker run --rm oc-cfg /bin/bash -c 'oc login @globals.openshift_apihost@ --token=@option.openshift_api_token@ && oc project cd && ./create-component.sh -p @option.project_id@ -c "@option.component_id@" -r @option.route@ -ne "@globals.nexus_host@"'
     keepgoing: false

--- a/rundeck-jobs/openshift/create-projects.yaml
+++ b/rundeck-jobs/openshift/create-projects.yaml
@@ -23,7 +23,7 @@
   sequence:
     commands:
     - description: echo input parameters
-      exec: 'echo project_id: ${option.project_id} openshift_api_token: bb${option.openshift_api_token}bb'
+      exec: 'echo project_id: ${option.project_id} openshift_api_token: <blinded>'
     - description: create tmp dir for job
       exec: mkdir /tmp/rundeck_${job.id}_${job.execid}
     - description: clone quickstarter project - origin/production
@@ -56,7 +56,7 @@
         sudo docker build -f Dockerfile-with-config --build-arg OC_IP=@globals.openshift_apihost_lookup@ -t oc-cfg .
     - description: create openshift projects (dev / test / cd with jenkins)
       script: |-
-        set -eux
+        set -eu # not using -x (tracing) to avoid disclosure of passwords/tokens
         cd "/tmp/rundeck_@job.id@_@job.execid@/ods-project-quickstarters/ocp-templates"
         sudo docker run --rm oc-cfg /bin/bash -c 'oc login @globals.openshift_apihost@ --token=@option.openshift_api_token@ && ./create-projects.sh -p @option.project_id@ -n @globals.nexus_host@ -a @option.project_admin@ -e @option.project_groups@'
     keepgoing: false

--- a/rundeck-jobs/openshift/create-rshiny.yaml
+++ b/rundeck-jobs/openshift/create-rshiny.yaml
@@ -61,7 +61,7 @@
         sudo docker build -f Dockerfile-with-config --build-arg OC_IP=@globals.openshift_apihost_lookup@ -t oc-cfg .
     - description: create openshift rshiny app cd project
       script: |-
-        set -eux
+        set -eu # not using -x (tracing) to avoid disclosure of passwords/tokens
         cd "/tmp/rundeck_@job.id@_@job.execid@/ods-project-quickstarters/ocp-templates"
         sudo docker run --rm oc-cfg /bin/bash -c 'oc login @globals.openshift_apihost@ --token=@option.openshift_api_token@ && oc project cd && ./create-rshiny-app.sh -p @option.project_id@ -c "@option.component_id@" '
     keepgoing: false

--- a/rundeck-jobs/openshift/delete-projects.yaml
+++ b/rundeck-jobs/openshift/delete-projects.yaml
@@ -19,7 +19,7 @@
   sequence:
     commands:
     - description: echo input parameters
-      exec: 'echo project_id: ${option.project_id} openshift_api_token: bb${option.openshift_api_token}bb'
+      exec: 'echo project_id: ${option.project_id} openshift_api_token: <blinded>'
     - description: create tmp dir for job
       exec: mkdir /tmp/rundeck_${job.id}_${job.execid}
     - description: clone oc script project

--- a/rundeck-jobs/quickstarts/airflow.yaml
+++ b/rundeck-jobs/quickstarts/airflow.yaml
@@ -34,7 +34,7 @@
     commands:
     - description: Printing input information
       script: |-
-        echo "openshift_api_token: @option.openshift_api_token@"
+        echo "openshift_api_token: <blinded>"
         echo "project_id: @opoption.project_id@"
         echo "component_id: @option.component_id@"
         echo "git_url_http: @option.git_url_https@"
@@ -62,7 +62,6 @@
         sudo docker build --build-arg OC_IP="@globals.openshift_apihost_lookup@" -t oc .
     - description: Create components
       script: |-
-        echo "Token --> @option.openshift_api_token@"
         cd "/tmp/rundeck_@job.id@_@job.execid@/ods-project-quickstarters/ocp-templates"
         sudo docker run \
         -v /tmp/rundeck_@job.id@_@job.execid@/ods-project-quickstarters/:/ods-project-quickstarters \

--- a/rundeck-jobs/quickstarts/be_python_flask.yaml
+++ b/rundeck-jobs/quickstarts/be_python_flask.yaml
@@ -31,9 +31,9 @@
   scheduleEnabled: true
   sequence:
     commands:
-    - exec: 'echo openshift_api_token: ${option.openshift_api_token} project_id: ${option.project_id},  component_id:
+    - exec: 'echo "openshift_api_token: <blinded> project_id: ${option.project_id},  component_id:
         ${option.component_id}, git_url_http: ${option.git_url_https}, git_url_ssh:
-        ${option.git_url_ssh}, package_name: ${option.package_name}'
+        ${option.git_url_ssh}, package_name: ${option.package_name}"'
     - description: checkout quickstart
       exec: mkdir /tmp/rundeck_${job.id}_${job.execid} && cd  /tmp/rundeck_${job.id}_${job.execid} && git clone ${globals.bitbucket_sshhost}/opendevstack/ods-project-quickstarters.git && cd ods-project-quickstarters && git checkout origin/production
     - description: init python flask project

--- a/rundeck-jobs/quickstarts/be_scala_akka.yaml
+++ b/rundeck-jobs/quickstarts/be_scala_akka.yaml
@@ -31,9 +31,9 @@
   scheduleEnabled: true
   sequence:
     commands:
-    - exec: 'echo openshift_api_token: ${option.openshift_api_token} project_id: ${option.project_id},  component_id:
+    - exec: 'echo "openshift_api_token: <blinded> project_id: ${option.project_id},  component_id:
         ${option.component_id}, git_url_http: ${option.git_url_http}, git_url_ssh:
-        ${option.git_url_ssh}, package_name: ${option.package_name}'
+        ${option.git_url_ssh}, package_name: ${option.package_name}"'
     - description: checkout quickstart
       exec: mkdir /tmp/rundeck_${job.id}_${job.execid} && cd  /tmp/rundeck_${job.id}_${job.execid} && git clone ${globals.bitbucket_sshhost}/opendevstack/ods-project-quickstarters && cd ods-project-quickstarters && git checkout origin/production
     - description: generate docker container for scala code

--- a/rundeck-jobs/quickstarts/ds_ml_service.yaml
+++ b/rundeck-jobs/quickstarts/ds_ml_service.yaml
@@ -31,9 +31,9 @@
   scheduleEnabled: true
   sequence:
     commands:
-    - exec: 'echo openshift_api_token: ${option.openshift_api_token} project_id: ${option.project_id},  component_id:
+    - exec: 'echo "openshift_api_token: <blinded> project_id: ${option.project_id},  component_id:
         ${option.component_id}, git_url_http: ${option.git_url_https}, git_url_ssh:
-        ${option.git_url_ssh}, package_name: ${option.package_name}'
+        ${option.git_url_ssh}, package_name: ${option.package_name}"'
     - description: create tmp dir for job
       exec: mkdir /tmp/rundeck_${job.id}_${job.execid}
     - description: clone quickstarter project - origin/production
@@ -70,7 +70,7 @@
         cd docker
         sudo docker build -f Dockerfile-with-config --build-arg OC_IP=@globals.openshift_apihost_lookup@ -t oc-cfg .
     - description: create components
-      exec: echo "Token --> ${option.openshift_api_token}" && cd /tmp/rundeck_${job.id}_${job.execid}/ods-project-quickstarters/ocp-templates  && sudo docker run --rm oc-cfg /bin/bash -c 'oc login ${globals.openshift_apihost} --token=${option.openshift_api_token} && oc project cd && ./custom-create-components.sh -p ${option.project_id} -c "${option.component_id}" -b "${option.git_url_http}" -ne "${globals.nexus_host}"'
+      exec: cd /tmp/rundeck_${job.id}_${job.execid}/ods-project-quickstarters/ocp-templates  && sudo docker run --rm oc-cfg /bin/bash -c 'oc login ${globals.openshift_apihost} --token=${option.openshift_api_token} && oc project cd && ./custom-create-components.sh -p ${option.project_id} -c "${option.component_id}" -b "${option.git_url_http}" -ne "${globals.nexus_host}"'
     - description: add Jenkinsfile to generated project
       script: |-
         sudo chown @globals.rundeck_os_user@ -R /tmp/rundeck_@job.id@_@job.execid@/@option.component_id@


### PR DESCRIPTION
closes #340 

I have not done solid testing in production so this could be too late for a 1.2 release. 
Please review with care so that we do not end up breaking the release. 

Note that this may not hit all credential disclosures only where I readily expected them. I believe this is a good starting point however. 

The changes involve credentials which are explicitly available in scripts
with dedicated parameters or other context variables which carry:
- password arguments
- generated secrets
- openshift api tokens.

A. Changes made in rundeck jobs:

- Echo of `${option.openshift_api_token}` either replaced
  with `<blinded>` or removed.
- Not using `set -x` (tracing) to avoid disclosure in executed commands.

NOTE:  Executing rundeck scripts with *Log level* `Debug` traces all
commands anyhow, which discloses secrets in the environment variables.

B. Reviewed boilerplates scripts and updated them:

- Not using `set -x` (tracing) in areas where otherwise creds would be
  disclosed.

C. Updated shared scripts in ocp-templates/scripts:

- Not using `set -x` (tracing) in areas where otherwise creds would be
  disclosed.

- Echo credentials as `<blinded>` as was already done in other places.