### PR TITLE
Point to next ODS version

### DIFF
--- a/boilerplates/airflow/Jenkinsfile
+++ b/boilerplates/airflow/Jenkinsfile
@@ -8,7 +8,7 @@ node {
     dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@production', retriever: modernSCM(
+library identifier: 'ods-library@2', retriever: modernSCM(
     [$class       : 'GitSCMSource',
         remote       : sharedLibraryRepository,
         credentialsId: credentialsId])

--- a/boilerplates/airflow/Jenkinsfile
+++ b/boilerplates/airflow/Jenkinsfile
@@ -15,7 +15,7 @@ library identifier: 'ods-library@2', retriever: modernSCM(
 
 // See readme of shared library for usage and customization.
 odsPipeline(
-    image: "${dockerRegistry}/cd/jenkins-slave-airflow",
+    image: "${dockerRegistry}/cd/jenkins-slave-airflow:2",
     projectId: projectId,
     componentId: componentId,
     openshiftBuildTimeout: 25,

--- a/boilerplates/be-docker-plain/Jenkinsfile
+++ b/boilerplates/be-docker-plain/Jenkinsfile
@@ -9,7 +9,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@production', retriever: modernSCM(
+library identifier: 'ods-library@2', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/be-docker-plain/Jenkinsfile
+++ b/boilerplates/be-docker-plain/Jenkinsfile
@@ -22,7 +22,7 @@ library identifier: 'ods-library@2', retriever: modernSCM(
   https://github.com/opendevstack/ods-core/tree/master/jenkins/slave-base
  */ 
 odsPipeline(
-  image: "${dockerRegistry}/cd/jenkins-slave-base",
+  image: "${dockerRegistry}/cd/jenkins-slave-base:2",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [

--- a/boilerplates/be-golang/Jenkinsfile
+++ b/boilerplates/be-golang/Jenkinsfile
@@ -9,7 +9,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@production', retriever: modernSCM(
+library identifier: 'ods-library@2', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/be-golang/Jenkinsfile
+++ b/boilerplates/be-golang/Jenkinsfile
@@ -22,7 +22,7 @@ library identifier: 'ods-library@2', retriever: modernSCM(
   https://github.com/opendevstack/ods-core/tree/master/jenkins/slave-base
  */
 odsPipeline(
-  image: "${dockerRegistry}/cd/jenkins-slave-golang",
+  image: "${dockerRegistry}/cd/jenkins-slave-golang:2",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [

--- a/boilerplates/be-node-express/Dockerfile
+++ b/boilerplates/be-node-express/Dockerfile
@@ -1,4 +1,4 @@
-FROM cd/jenkins-slave-nodejs8-angular
+FROM cd/jenkins-slave-nodejs8-angular:2
 
 MAINTAINER "Andreas Bellmann" <andreas.bellmann@opitz-consulting.com>
 

--- a/boilerplates/be-node-express/Jenkinsfile
+++ b/boilerplates/be-node-express/Jenkinsfile
@@ -9,7 +9,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@production', retriever: modernSCM(
+library identifier: 'ods-library@2', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/be-node-express/Jenkinsfile
+++ b/boilerplates/be-node-express/Jenkinsfile
@@ -22,7 +22,7 @@ library identifier: 'ods-library@2', retriever: modernSCM(
   https://github.com/opendevstack/ods-project-quickstarters/tree/master/jenkins-slaves/nodejs8-angular
  */
 odsPipeline(
-  image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular",
+  image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular:2",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [

--- a/boilerplates/be-node-express/build.sh
+++ b/boilerplates/be-node-express/build.sh
@@ -1,6 +1,6 @@
 #1/bin/bash
 YO_VERSION=2.0.0
-JENKINS_SLAVE=cd/jenkins-slave-nodejs8-angular:latest
+JENKINS_SLAVE=cd/jenkins-slave-nodejs8-angular:2
 
 while [[ $# -gt 1 ]]
 do

--- a/boilerplates/be-python-flask/Jenkinsfile
+++ b/boilerplates/be-python-flask/Jenkinsfile
@@ -9,7 +9,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@production', retriever: modernSCM(
+library identifier: 'ods-library@2', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/be-python-flask/Jenkinsfile
+++ b/boilerplates/be-python-flask/Jenkinsfile
@@ -22,7 +22,7 @@ library identifier: 'ods-library@2', retriever: modernSCM(
   https://github.com/opendevstack/ods-project-quickstarters/tree/master/jenkins-slaves/python
  */
 odsPipeline(
-  image: "${dockerRegistry}/cd/jenkins-slave-python",
+  image: "${dockerRegistry}/cd/jenkins-slave-python:2",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [

--- a/boilerplates/be-scala-akka/Jenkinsfile
+++ b/boilerplates/be-scala-akka/Jenkinsfile
@@ -9,7 +9,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@production', retriever: modernSCM(
+library identifier: 'ods-library@2', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/be-scala-akka/build.sh
+++ b/boilerplates/be-scala-akka/build.sh
@@ -1,6 +1,6 @@
 #1/bin/bash
 SCALA_VERSION=2.11.8
-JENKINS_SLAVE=cd/jenkins-slave-scala:latest
+JENKINS_SLAVE=cd/jenkins-slave-scala:2
 
 while [[ $# -gt 1 ]]
 do

--- a/boilerplates/be-springboot/Jenkinsfile
+++ b/boilerplates/be-springboot/Jenkinsfile
@@ -9,7 +9,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@production', retriever: modernSCM(
+library identifier: 'ods-library@2', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/be-springboot/build.sh
+++ b/boilerplates/be-springboot/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SPRING_CLI_VERSION=2.0.2.RELEASE
-JENKINS_SLAVE=cd/jenkins-slave-maven:latest
+JENKINS_SLAVE=cd/jenkins-slave-maven:2
 
 while [[ $# -gt 1 ]]
 do

--- a/boilerplates/ds-ml-service/Jenkinsfile
+++ b/boilerplates/ds-ml-service/Jenkinsfile
@@ -16,7 +16,7 @@ node {
     dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@production', retriever: modernSCM(
+library identifier: 'ods-library@2', retriever: modernSCM(
     [$class       : 'GitSCMSource',
         remote       : sharedLibraryRepository,
         credentialsId: credentialsId])

--- a/boilerplates/ds-ml-service/Jenkinsfile
+++ b/boilerplates/ds-ml-service/Jenkinsfile
@@ -23,7 +23,7 @@ library identifier: 'ods-library@2', retriever: modernSCM(
 
 // See readme of shared library for usage and customization.
 odsPipeline(
-    image: "${dockerRegistry}/cd/jenkins-slave-python",
+    image: "${dockerRegistry}/cd/jenkins-slave-python:2",
     projectId: projectId,
     componentId: componentId,
     testResults : 'tests-results',

--- a/boilerplates/e2e-cypress/Jenkinsfile
+++ b/boilerplates/e2e-cypress/Jenkinsfile
@@ -9,7 +9,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@production', retriever: modernSCM(
+library identifier: 'ods-library@2', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/e2e-cypress/Jenkinsfile
+++ b/boilerplates/e2e-cypress/Jenkinsfile
@@ -22,7 +22,7 @@ library identifier: 'ods-library@2', retriever: modernSCM(
   https://github.com/opendevstack/ods-project-quickstarters/tree/master/jenkins-slaves/nodejs8-angular
  */ 
 odsPipeline(
-  image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular",
+  image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular:2",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [

--- a/boilerplates/fe-angular/Jenkinsfile
+++ b/boilerplates/fe-angular/Jenkinsfile
@@ -9,7 +9,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@production', retriever: modernSCM(
+library identifier: 'ods-library@2', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/fe-angular/build.sh
+++ b/boilerplates/fe-angular/build.sh
@@ -5,7 +5,7 @@
 # see details on bottom of "./init.sh"
 ANGULAR_CLI_VERSION=8.0.3
 
-JENKINS_SLAVE=cd/jenkins-slave-nodejs10-angular:latest
+JENKINS_SLAVE=cd/jenkins-slave-nodejs10-angular:2
 
 while [[ $# -gt 1 ]]
 do

--- a/boilerplates/fe-ionic/Jenkinsfile
+++ b/boilerplates/fe-ionic/Jenkinsfile
@@ -9,7 +9,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@production', retriever: modernSCM(
+library identifier: 'ods-library@2', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/fe-ionic/Jenkinsfile
+++ b/boilerplates/fe-ionic/Jenkinsfile
@@ -22,7 +22,7 @@ library identifier: 'ods-library@2', retriever: modernSCM(
   https://github.com/opendevstack/ods-project-quickstarters/tree/master/jenkins-slaves/nodejs8-angular
  */
 odsPipeline(
-  image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular",
+  image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular:2",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [

--- a/boilerplates/fe-react/Jenkinsfile
+++ b/boilerplates/fe-react/Jenkinsfile
@@ -9,7 +9,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@production', retriever: modernSCM(
+library identifier: 'ods-library@2', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/fe-react/Jenkinsfile
+++ b/boilerplates/fe-react/Jenkinsfile
@@ -22,7 +22,7 @@ library identifier: 'ods-library@2', retriever: modernSCM(
   https://github.com/opendevstack/ods-project-quickstarters/tree/master/jenkins-slaves/nodejs8-angular
  */
 odsPipeline(
-  image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular",
+  image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular:2",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [

--- a/boilerplates/fe-vue/Dockerfile
+++ b/boilerplates/fe-vue/Dockerfile
@@ -1,4 +1,4 @@
-FROM cd/jenkins-slave-nodejs8-angular
+FROM cd/jenkins-slave-nodejs8-angular:2
 
 LABEL maintainer="Akhil Soman <akhil.soman@boehringer-ingelheim.com>"
 

--- a/boilerplates/fe-vue/Jenkinsfile
+++ b/boilerplates/fe-vue/Jenkinsfile
@@ -8,7 +8,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@production', retriever: modernSCM(
+library identifier: 'ods-library@2', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/fe-vue/Jenkinsfile
+++ b/boilerplates/fe-vue/Jenkinsfile
@@ -15,7 +15,7 @@ library identifier: 'ods-library@2', retriever: modernSCM(
 
 // See readme of shared library for usage and customization.
 odsPipeline(
-  image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular",
+  image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular:2",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [

--- a/boilerplates/jupyter-notebook/Jenkinsfile
+++ b/boilerplates/jupyter-notebook/Jenkinsfile
@@ -22,7 +22,7 @@ library identifier: 'ods-library@2', retriever: modernSCM(
   https://github.com/opendevstack/ods-core/tree/master/jenkins/slave-base
  */
 odsPipeline(
-  image: "${dockerRegistry}/cd/jenkins-slave-base",
+  image: "${dockerRegistry}/cd/jenkins-slave-base:2",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [

--- a/boilerplates/jupyter-notebook/Jenkinsfile
+++ b/boilerplates/jupyter-notebook/Jenkinsfile
@@ -9,7 +9,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@production', retriever: modernSCM(
+library identifier: 'ods-library@2', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/boilerplates/release-manager/files/Jenkinsfile
+++ b/boilerplates/release-manager/files/Jenkinsfile
@@ -1,6 +1,6 @@
-@Library('ods-mro-jenkins-shared-library@production')
+@Library('ods-mro-jenkins-shared-library@2')
 
-@Library('ods-jenkins-shared-library@production')
+@Library('ods-jenkins-shared-library@2')
 
 def project = [:]
 def repos   = []

--- a/boilerplates/rshiny-app/Jenkinsfile
+++ b/boilerplates/rshiny-app/Jenkinsfile
@@ -22,7 +22,7 @@ library identifier: 'ods-library@2', retriever: modernSCM(
   https://github.com/opendevstack/ods-core/tree/master/jenkins/slave-base
  */
 odsPipeline(
-  image: "${dockerRegistry}/cd/jenkins-slave-base",
+  image: "${dockerRegistry}/cd/jenkins-slave-base:2",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [

--- a/boilerplates/rshiny-app/Jenkinsfile
+++ b/boilerplates/rshiny-app/Jenkinsfile
@@ -9,7 +9,7 @@ node {
   dockerRegistry = env.DOCKER_REGISTRY
 }
 
-library identifier: 'ods-library@production', retriever: modernSCM(
+library identifier: 'ods-library@2', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: sharedLibraryRepository,
    credentialsId: credentialsId])

--- a/jenkins-slaves/airflow/Dockerfile.rhel7
+++ b/jenkins-slaves/airflow/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM cd/jenkins-slave-base
+FROM cd/jenkins-slave-base:2
 
 LABEL maintainer="Gerard Castillo <gerard.castillo@boehringer-ingelheim.com>"
 

--- a/jenkins-slaves/airflow/ocp-config/bc.yml
+++ b/jenkins-slaves/airflow/ocp-config/bc.yml
@@ -14,7 +14,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: jenkins-slave-airflow:latest
+        name: jenkins-slave-airflow:2
     postCommit: {}
     resources: {}
     runPolicy: Serial
@@ -36,7 +36,7 @@ objects:
             value: ${NEXUS_AUTH}
         from:
           kind: ImageStreamTag
-          name: jenkins-slave-base:latest
+          name: jenkins-slave-base:2
       type: Docker
     triggers: []
 parameters:

--- a/jenkins-slaves/golang/Dockerfile.rhel7
+++ b/jenkins-slaves/golang/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM cd/jenkins-slave-base
+FROM cd/jenkins-slave-base:2
 
 LABEL maintainer="Michael Sauter <michael.sauter@boehringer-ingelheim.com>"
 

--- a/jenkins-slaves/golang/ocp-config/bc.yml
+++ b/jenkins-slaves/golang/ocp-config/bc.yml
@@ -15,7 +15,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: jenkins-slave-golang:latest
+        name: jenkins-slave-golang:2
     postCommit: {}
     resources: {}
     runPolicy: Serial
@@ -32,7 +32,7 @@ objects:
         dockerfilePath: Dockerfile.rhel7
         from:
           kind: ImageStreamTag
-          name: jenkins-slave-base:latest
+          name: jenkins-slave-base:2
       type: Docker
     successfulBuildsHistoryLimit: 5
     triggers: []

--- a/jenkins-slaves/maven/Dockerfile.rhel7
+++ b/jenkins-slaves/maven/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM cd/jenkins-slave-base
+FROM cd/jenkins-slave-base:2
 
 MAINTAINER Michael Sauter <michael.sauter@boehringer-ingelheim.com>
 

--- a/jenkins-slaves/maven/ocp-config/bc.yml
+++ b/jenkins-slaves/maven/ocp-config/bc.yml
@@ -14,7 +14,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: jenkins-slave-maven:latest
+        name: jenkins-slave-maven:2
     postCommit: {}
     resources: {}
     runPolicy: Serial
@@ -38,7 +38,7 @@ objects:
             value: ${NEXUS_PASSWORD}
         from:
           kind: ImageStreamTag
-          name: jenkins-slave-base:latest
+          name: jenkins-slave-base:2
       type: Docker
     triggers: []
 parameters:

--- a/jenkins-slaves/nodejs10-angular/Dockerfile.rhel7
+++ b/jenkins-slaves/nodejs10-angular/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM cd/jenkins-slave-base
+FROM cd/jenkins-slave-base:2
 
 MAINTAINER Richard Attermeyer <richard.attermeyer@opitz-consulting.com>
 

--- a/jenkins-slaves/nodejs10-angular/ocp-config/bc.yml
+++ b/jenkins-slaves/nodejs10-angular/ocp-config/bc.yml
@@ -15,7 +15,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: jenkins-slave-nodejs10-angular:latest
+        name: jenkins-slave-nodejs10-angular:2
     postCommit: {}
     resources: {}
     runPolicy: Serial
@@ -37,7 +37,7 @@ objects:
             value: ${NEXUS_AUTH}
         from:
           kind: ImageStreamTag
-          name: jenkins-slave-base:latest
+          name: jenkins-slave-base:2
       type: Docker
     successfulBuildsHistoryLimit: 5
     triggers: []

--- a/jenkins-slaves/nodejs8-angular/Dockerfile.rhel7
+++ b/jenkins-slaves/nodejs8-angular/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM cd/jenkins-slave-base
+FROM cd/jenkins-slave-base:2
 
 MAINTAINER Richard Attermeyer <richard.attermeyer@opitz-consulting.com>
 

--- a/jenkins-slaves/nodejs8-angular/ocp-config/bc.yml
+++ b/jenkins-slaves/nodejs8-angular/ocp-config/bc.yml
@@ -14,7 +14,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: jenkins-slave-nodejs8-angular:latest
+        name: jenkins-slave-nodejs8-angular:2
     postCommit: {}
     resources: {}
     runPolicy: Serial
@@ -36,7 +36,7 @@ objects:
             value: ${NEXUS_AUTH}
         from:
           kind: ImageStreamTag
-          name: jenkins-slave-base:latest
+          name: jenkins-slave-base:2
       type: Docker
     triggers: []
 parameters:

--- a/jenkins-slaves/python/Dockerfile.rhel7
+++ b/jenkins-slaves/python/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM cd/jenkins-slave-base
+FROM cd/jenkins-slave-base:2
 
 MAINTAINER Michael Sauter <michael.sauter@boehringer-ingelheim.com>
 

--- a/jenkins-slaves/python/ocp-config/bc.yml
+++ b/jenkins-slaves/python/ocp-config/bc.yml
@@ -14,7 +14,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: jenkins-slave-python:latest
+        name: jenkins-slave-python:2
     postCommit: {}
     resources: {}
     runPolicy: Serial
@@ -31,7 +31,7 @@ objects:
         dockerfilePath: Dockerfile.rhel7
         from:
           kind: ImageStreamTag
-          name: jenkins-slave-base:latest
+          name: jenkins-slave-base:2
       type: Docker
     triggers: []
 parameters:

--- a/jenkins-slaves/scala/Dockerfile.rhel7
+++ b/jenkins-slaves/scala/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM cd/jenkins-slave-base
+FROM cd/jenkins-slave-base:2
 
 MAINTAINER Clemens Utschig <clemens.utschig-utschig@boehringer-ingelheim.com>
 

--- a/jenkins-slaves/scala/ocp-config/bc.yml
+++ b/jenkins-slaves/scala/ocp-config/bc.yml
@@ -14,7 +14,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: jenkins-slave-scala:latest
+        name: jenkins-slave-scala:2
     postCommit: {}
     resources: {}
     runPolicy: Serial
@@ -38,7 +38,7 @@ objects:
             value: ${NEXUS_PASSWORD}
         from:
           kind: ImageStreamTag
-          name: jenkins-slave-base:latest
+          name: jenkins-slave-base:2
       type: Docker
     triggers: []
 parameters:

--- a/ocp-templates/Dockerfile
+++ b/ocp-templates/Dockerfile
@@ -1,4 +1,4 @@
-FROM cd/jenkins-slave-base
+FROM cd/jenkins-slave-base:2
 
 MAINTAINER "Andreas Bellmann" <andreas.bellmann@opitz-consulting.com>
 

--- a/ocp-templates/Dockerfile-with-config
+++ b/ocp-templates/Dockerfile-with-config
@@ -1,4 +1,4 @@
-FROM cd/jenkins-slave-base
+FROM cd/jenkins-slave-base:2
 
 MAINTAINER "Andreas Bellmann" <andreas.bellmann@opitz-consulting.com>
 

--- a/ocp-templates/ocp-config/cd-docgen/cd-docgen.yml
+++ b/ocp-templates/ocp-config/cd-docgen/cd-docgen.yml
@@ -49,7 +49,7 @@ objects:
             env: 'cd'
         spec:
           containers:
-            - image: 'cd/docgen:latest'
+            - image: 'cd/docgen:2'
               imagePullPolicy: IfNotPresent
               name: 'docgen'
               ports:
@@ -93,7 +93,7 @@ objects:
               - 'docgen'
             from:
               kind: ImageStreamTag
-              name: 'docgen:latest'
+              name: 'docgen:2'
               namespace: cd
           type: ImageChange
 parameters:

--- a/ocp-templates/ocp-config/cd-jenkins-master/cd-jenkins-master.yml
+++ b/ocp-templates/ocp-config/cd-jenkins-master/cd-jenkins-master.yml
@@ -294,7 +294,7 @@ parameters:
 - name: NAMESPACE
   value: cd
 - name: JENKINS_IMAGE_STREAM_TAG
-  value: jenkins-master:latest
+  value: jenkins-master:2
 - name: CD_USER_ID
   required: true
 - name: CD_USER_PWD

--- a/ocp-templates/ocp-config/cd-jenkins-master/cd-jenkins-webhook-proxy.yml
+++ b/ocp-templates/ocp-config/cd-jenkins-master/cd-jenkins-webhook-proxy.yml
@@ -100,7 +100,7 @@ objects:
         - webhook-proxy
         from:
           kind: ImageStreamTag
-          name: jenkins-webhook-proxy:latest
+          name: jenkins-webhook-proxy:2
           namespace: '${NAMESPACE}'
       type: ImageChange
 - apiVersion: v1

--- a/ocp-templates/ocp-config/rshiny-app/rshiny.yml
+++ b/ocp-templates/ocp-config/rshiny-app/rshiny.yml
@@ -130,7 +130,7 @@ objects:
           - ${COMPONENT}
           from:
             kind: ImageStreamTag
-            name: ${COMPONENT}:latest
+            name: ${COMPONENT}:2
             namespace: ${PROJECT}-${ENV}
         type: ImageChange
     status: {}

--- a/rundeck-jobs/common/verify global rundeck settings.yaml
+++ b/rundeck-jobs/common/verify global rundeck settings.yaml
@@ -20,7 +20,7 @@
     - description: verify openshift registry access
       exec: sudo docker login -u ${globals.openshift_user} -p ${option.openshift_api_token} ${globals.openshift_dockerregistry}
     - description: Pull and tag jenkins slave
-      exec: sudo docker pull ${globals.openshift_dockerregistry}/cd/jenkins-slave-base && sudo docker tag ${globals.openshift_dockerregistry}/cd/jenkins-slave-base cd/jenkins-slave-base:latest
+      exec: sudo docker pull ${globals.openshift_dockerregistry}/cd/jenkins-slave-base:2 && sudo docker tag ${globals.openshift_dockerregistry}/cd/jenkins-slave-base cd/jenkins-slave-base:latest
     - description: create tmp dir for job
       exec: mkdir /tmp/rundeck_${job.id}_${job.execid}
     - description: clone oc script project

--- a/rundeck-jobs/quickstarts/airflow.yaml
+++ b/rundeck-jobs/quickstarts/airflow.yaml
@@ -58,7 +58,7 @@
       script: |-
         cd "/tmp/rundeck_@job.id@_@job.execid@/ods-project-quickstarters/ocp-templates"
 
-        sudo docker pull cd/jenkins-slave-base
+        sudo docker pull cd/jenkins-slave-base:2
         sudo docker build --build-arg OC_IP="@globals.openshift_apihost_lookup@" -t oc .
     - description: Create components
       script: |-


### PR DESCRIPTION
Follow-up from https://github.com/opendevstack/ods-core/pull/212.

I anticipate another change to this which should make management of the version a bit easier, see https://github.com/opendevstack/ods-core/issues/225.